### PR TITLE
Restores original title and link to HSTS preloading page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -31,5 +31,5 @@ data:
 support:
   - text: DNS
     href: /support/dns/
-  - text: Security
-    href: /support/security/
+  - text: HSTS Preloading
+    href: /hsts-preloading/

--- a/pages/home.md
+++ b/pages/home.md
@@ -22,9 +22,9 @@ hero:
 </div>
 
 <div class="usa-width-two-thirds">
-**May 15, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/support/security/#hstshttps-preloading) went into effect for newly issued federal executive branch domains.
+**May 15, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) went into effect for newly issued federal executive branch domains.
 
-**January 19, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/support/security/#hstshttps-preloading) was [announced](https://cio.gov/automatic-https-enforcement-new-executive-branch-gov-domains/). This service will automatically enforce HTTPS for newly issued federal executive branch .gov domains.
+**January 19, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) was [announced](https://cio.gov/automatic-https-enforcement-new-executive-branch-gov-domains/). This service will automatically enforce HTTPS for newly issued federal executive branch .gov domains.
 
 **January 1, 2017:** The [fee increase]({{ site.baseurl }}/registration/fees/#2017-fee-increase) went into effect, raising the annual fee for domains to $400 per year.
 </div>

--- a/pages/support/security.md
+++ b/pages/support/security.md
@@ -1,17 +1,19 @@
 ---
-title: Security
+title: HSTS Preloading
 layout: docs
-permalink: /support/security/
+permalink: /hsts-preloading/
 
 sidenav: support
 subnav:
-  - text: HSTS/HTTPS preloading
-    href: '#hstshttps-preloading'
+  - text: Introduction
+    href: '#introduction'
   - text: Certificates
     href: '#certificates'
+
+
 ---
 
-## HSTS/HTTPS preloading
+## Introduction
 
 Dotgov.gov has begun automatically implementing the preloading of HTTP Strict Transport Security records ("HSTS Preloading") for newly issued **federal executive branch** .gov domains.
 


### PR DESCRIPTION
This restores the title and URL of `/hsts-preloading/` to the page about HSTS/HTTPS preloading. The primary reason here is for SEO purposes, based on HSTS preloading being something we want to draw extra attention to, particularly among novel audiences (such as other TLDs, and other technical communities of interest).

We may want to restore it to a primary place in the nav in the future, as well for the same reason, but this at least gets the URL and `<title>` tags in place.