### PR TITLE
Update URLs to use master branch and GitHub's preferred raw URL

### DIFF
--- a/pages/data.md
+++ b/pages/data.md
@@ -14,11 +14,11 @@ subnav:
 
 The official public list of `.gov` domains is updated about every two weeks:
 
-* [List of .gov domains](https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-full.csv) - includes federal, state, local, and tribal `.gov` and `.fed.us` domains.
+* [List of .gov domains](https://github.com/GSA/data/raw/master/dotgov-domains/current-full.csv) - includes federal, state, local, and tribal `.gov` and `.fed.us` domains.
 
 ### Federal .gov domains
 
-* [List of federal .gov domains](https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-federal.csv) - includes federal `.gov` and `.fed.us` domains only. (This is a subset of the full list.)
+* [List of federal .gov domains](https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv) - includes federal `.gov` and `.fed.us` domains only. (This is a subset of the full list.)
 
 ### Share your feedback
 


### PR DESCRIPTION
This PR gets the dotgov home page away from using the `gh-pages` branch of github.com/gsa/data and uses the `master` branch. It also uses the intermediate raw URLs preferred and advertised by GitHub.