### PR TITLE
Drop the relative URL

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -11,7 +11,7 @@ layout: base
     </h2>
     <h2 class="hero-heading hero-heading-content">{{ hero.content }}</h2>
     <a class="usa-button usa-button-big usa-button-primary-alt"
-      href="{{ hero.button.href | relative_url }}">
+      href="{{ hero.button.href }}">
       {{ hero.button.text }}
     </a>
     <a class="hero-link" href="{{ hero.link.href }}">{{ hero.link.text }}</a>


### PR DESCRIPTION
This PR moves the definition of the anchor for hero button to be inside the home page file itself.