### PR TITLE
Password update page

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -22,11 +22,11 @@ hero:
 </div>
 
 <div class="usa-width-two-thirds">
-**February 2018:** [All new Federal executive branch .gov domain requests]({{ site.baseurl }}/registration/requirements/#federal-domains) became subject to additional review and approval by the Office of Management and Budget (OMB). Domain renewals will not be subject to additional review. 
-  
-**May 15, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) went into effect for newly issued federal executive branch domains.
+**April 17, 2018:** A security feature was added to the [.gov registrar](https://domains.dotgov.gov) to prevent the use of [passwords that have been identified in various publicly known data breaches]({{ site.baseurl }}/password-update/).
 
-**January 19, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) was [announced](https://www.cio.gov/2017/01/19/automatic-https-enforcement-new-executive-branch-gov-domains/). This service will automatically enforce HTTPS for newly issued federal executive branch .gov domains.
+**February 2018:** [All new Federal executive branch .gov domain requests]({{ site.baseurl }}/registration/requirements/#federal-domains) became subject to additional review and approval by the Office of Management and Budget (OMB). Domain renewals will not be subject to additional review.
+
+**May 15, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) went into effect for newly issued federal executive branch domains.
 </div>
 </div>
 </section>

--- a/pages/home.md
+++ b/pages/home.md
@@ -22,7 +22,7 @@ hero:
 </div>
 
 <div class="usa-width-two-thirds">
-**April 17, 2018:** A security feature was added to the [.gov registrar](https://domains.dotgov.gov) to prevent the use of [passwords that have been identified in various publicly known data breaches]({{ site.baseurl }}/password-update/).
+**April 17, 2018:** A security feature was added to the [DotGov registrar](https://domains.dotgov.gov) to prevent the use of [passwords that have been identified in various publicly known data breaches]({{ site.baseurl }}/password-update/).
 
 **February 2018:** [All new Federal executive branch .gov domain requests]({{ site.baseurl }}/registration/requirements/#federal-domains) became subject to additional review and approval by the Office of Management and Budget (OMB). Domain renewals will not be subject to additional review.
 

--- a/pages/password-update.md
+++ b/pages/password-update.md
@@ -1,0 +1,21 @@
+---
+title: Password update
+layout: docs
+permalink: /password-update/
+---
+
+The .gov registrar has added a security feature to prevent the use of passwords that have been identified in various publicly known data breaches. **All users will need to update their password** – even if your password has not been re-used or breached – so that we can add this protection to each user account.
+
+## Why is this change happening?
+The secrecy of your password is crucial to account security, and password reuse is the most common threat to password secrecy. An attacker who breaches one system’s password can often pivot to another system using those credentials.
+
+By ensuring that [passwords found in data taken from past public breaches](https://www.troyhunt.com/introducing-306-million-freely-downloadable-pwned-passwords/) cannot be used, we minimize the threat of password reuse.
+
+To do this, we have to ask **all** users to reset their passwords, because the only practical way for us to implement this check is to do it at the moment a user selects a password. After a user sets their password, it is stored in such a way that it cannot efficiently be checked against lists of known-breached passwords.
+
+To be clear, this action is **not** being taken because of a breach on any DotGov-related system. The General Services Administration is proactively working to improve the security of the .gov zone for its users and administrators.
+
+## What should I do now?
+1. Change your password at https://domains.dotgov.gov. If it’s in a publicly known data breach, you will told to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.
+
+2. We **strongly recommend that you use a password manager** to generate and store a long, complex, unique password used only for the DotGov service.

--- a/pages/password-update.md
+++ b/pages/password-update.md
@@ -4,18 +4,18 @@ layout: docs
 permalink: /password-update/
 ---
 
-The .gov registrar has added a security feature to prevent the use of passwords that have been identified in various publicly known data breaches. **All users will need to update their password** – even if your password has not been re-used or breached – so that we can add this protection to each user account.
+The DotGov registrar has added a security feature to prevent the use of passwords that have been identified in various publicly known data breaches. **All DotGov users will need to update their password** – even if your password has not been re-used or breached – so that we can add this protection to each user account.
 
 ## Why is this change happening?
 The secrecy of your password is crucial to account security, and password reuse is the most common threat to password secrecy. An attacker who breaches one system’s password can often pivot to another system using those credentials.
 
 By ensuring that [passwords found in data taken from past public breaches](https://www.troyhunt.com/introducing-306-million-freely-downloadable-pwned-passwords/) cannot be used, we minimize the threat of password reuse.
 
-To do this, we have to ask **all** users to reset their passwords, because the only practical way for us to implement this check is to do it at the moment a user selects a password. After a user sets their password, it is stored in such a way that it cannot efficiently be checked against lists of known-breached passwords.
+To do this, we have to ask **all** DotGov users to reset their passwords, because the only practical way for us to implement this check is to do it at the moment a user selects a password. After a user sets their password, it is stored in such a way that it cannot efficiently be checked against lists of known-breached passwords.
 
 To be clear, this action is **not** being taken because of a breach on any DotGov-related system. The General Services Administration is proactively working to improve the security of the .gov zone for its users and administrators.
 
-## What should I do now?
+## What should DotGov users do now?
 1. Change your password at [https://domains.dotgov.gov](https://domains.dotgov.gov). If it’s in a publicly known data breach, you will told to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.
 
 2. We **strongly recommend that you use a password manager** to generate and store a long, complex, unique password used only for the DotGov service.

--- a/pages/password-update.md
+++ b/pages/password-update.md
@@ -4,7 +4,7 @@ layout: docs
 permalink: /password-update/
 ---
 
-The DotGov registrar has added a security feature to prevent the use of passwords that have been identified in various publicly known data breaches. **All DotGov users will need to update their password** – even if your password has not been re-used or breached – so that we can add this protection to each user account.
+The DotGov registrar has added a security feature to prevent the use of passwords that have been identified in various publicly known data breaches. **All DotGov users will need to update their password** – even if your password has not been re-used or breached – in order for your account to be protected.
 
 ## Why is this change happening?
 The secrecy of your password is crucial to account security, and password reuse is the most common threat to password secrecy. An attacker who breaches one system’s password can often pivot to another system using those credentials.
@@ -16,6 +16,6 @@ To do this, we have to ask **all** DotGov users to reset their passwords, becaus
 To be clear, this action is **not** being taken because of a breach on any DotGov-related system. The General Services Administration is proactively working to improve the security of the .gov zone for its users and administrators.
 
 ## What should DotGov users do now?
-1. Change your password at [https://domains.dotgov.gov](https://domains.dotgov.gov). If it’s in a publicly known data breach, you will told to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.
+1. We **strongly recommend that you use a password manager** to generate and store a long, complex, unique password used only for the DotGov service.
 
-2. We **strongly recommend that you use a password manager** to generate and store a long, complex, unique password used only for the DotGov service.
+2. Change your password at [https://domains.dotgov.gov](https://domains.dotgov.gov). If it’s in a publicly known data breach, you will be asked to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.

--- a/pages/password-update.md
+++ b/pages/password-update.md
@@ -16,6 +16,6 @@ To do this, we have to ask **all** users to reset their passwords, because the o
 To be clear, this action is **not** being taken because of a breach on any DotGov-related system. The General Services Administration is proactively working to improve the security of the .gov zone for its users and administrators.
 
 ## What should I do now?
-1. Change your password at https://domains.dotgov.gov. If it’s in a publicly known data breach, you will told to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.
+1. Change your password at [https://domains.dotgov.gov](https://domains.dotgov.gov). If it’s in a publicly known data breach, you will told to select a different one. _If you get this alert and it’s a password you use anywhere else_, we urge you to **change your password in those applications**, too.
 
 2. We **strongly recommend that you use a password manager** to generate and store a long, complex, unique password used only for the DotGov service.


### PR DESCRIPTION
This change adds a page that outlines the rationale behind making `passwords from public data breaches` unavailable to DotGov users, and gives guidance to users.