### PR TITLE
Remove fax number request from authorization letter templates

### DIFF
--- a/pages/forms/city.md
+++ b/pages/forms/city.md
@@ -29,21 +29,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/county.md
+++ b/pages/forms/county.md
@@ -30,21 +30,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/federal.md
+++ b/pages/forms/federal.md
@@ -29,21 +29,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/interstate.md
+++ b/pages/forms/interstate.md
@@ -33,21 +33,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/native-sovereign-nation.md
+++ b/pages/forms/native-sovereign-nation.md
@@ -30,21 +30,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/state.md
+++ b/pages/forms/state.md
@@ -29,21 +29,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  

--- a/pages/forms/us-territory.md
+++ b/pages/forms/us-territory.md
@@ -29,21 +29,21 @@ Administrative Point of Contact
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Billing Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Technical Point of Contact  
 First Name, Last Name  
 Title  
 Address  
-Phone/Fax Number  
+Phone Number  
 Email Address  
 
 Sincerely,  


### PR DESCRIPTION
This small change removes the request for a fax number from our authorization letter template.