### PR TITLE
Announcing HSTS opt-in

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -22,11 +22,11 @@ hero:
 </div>
 
 <div class="usa-width-two-thirds">
+**August 21, 2018:** New .gov domains can opt-in to [automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) at the time of registration.
+
 **April 17, 2018:** A security feature was added to the [DotGov registrar](https://domains.dotgov.gov) to prevent the use of [passwords that have been identified in various publicly known data breaches]({{ site.baseurl }}/password-update/).
 
 **February 2018:** [All new Federal executive branch .gov domain requests]({{ site.baseurl }}/registration/requirements/#federal-domains) became subject to additional review and approval by the Office of Management and Budget (OMB). Domain renewals will not be subject to additional review.
-
-**May 15, 2017:** [Automatic HSTS/HTTPS preloading]({{ site.baseurl }}/hsts-preloading/) went into effect for newly issued federal executive branch domains.
 </div>
 </div>
 </section>

--- a/pages/support/security.md
+++ b/pages/support/security.md
@@ -15,7 +15,9 @@ subnav:
 
 ## Introduction
 
-Dotgov.gov has begun automatically implementing the preloading of HTTP Strict Transport Security records ("HSTS Preloading") for newly issued **federal executive branch** .gov domains. We also allow any other new domain registrations to opt-in to preloading.
+Dotgov.gov has begun automatically implementing the preloading of HTTP Strict Transport Security records ("HSTS Preloading") for newly issued **federal executive branch** .gov domains.
+
+Newly registered domains from outside the federal executive branch can also **opt-in** to preloading.
 
 ### What is HTTPS and why is it important?
 

--- a/pages/support/security.md
+++ b/pages/support/security.md
@@ -15,7 +15,7 @@ subnav:
 
 ## Introduction
 
-Dotgov.gov has begun automatically implementing the preloading of HTTP Strict Transport Security records ("HSTS Preloading") for newly issued **federal executive branch** .gov domains.
+Dotgov.gov has begun automatically implementing the preloading of HTTP Strict Transport Security records ("HSTS Preloading") for newly issued **federal executive branch** .gov domains. We also allow any other new domain registrations to opt-in to preloading.
 
 ### What is HTTPS and why is it important?
 
@@ -41,15 +41,15 @@ By preloading [whitehouse.gov](https://whitehouse.gov), the site owners have ens
 
 ### Will automatic preloading affect non-executive branch federal domains and websites?
 
-**No.** If a .gov domain belongs to the federal government's legislative or judicial branches, it will not be affected by HTTPS preloading.
+**No.** If a .gov domain belongs to the federal government's legislative or judicial branches, it will not be affected by HTTPS preloading. However, new domains from these branches can opt-in to preloading at the time of registration.
 
 ### Will automatic preloading affect state or local government, or Native tribe domains and websites?
 
-**No.** If a .gov domain belongs to a native tribe, state, or local government entity, it will not be affected by HTTPS preloading.
+**No.** If a .gov domain belongs to a native tribe, state, or local government entity, it will not be affected by HTTPS preloading. However, new domains from these government entities can opt-in to preloading at the time of registration.
 
 ### Will automatic preloading affect domains registered before May 15, 2017?
 
-**No.** If a .gov domain was registered before May 15, 2017, it will not be affected by the HTTPS preloading.
+**No.** If a .gov domain was registered before May 15, 2017, it will not be affected by automatic HTTPS preloading.
 
 Note: It's possible for any .gov domain owner to preload their own domain. Some domains not meeting the above criteria have been preloaded through the domain owner's direct action, and could be affected. This service only applies to identifying domains preloaded through the DotGov.gov program's action, rather than the domain owner's action.
 


### PR DESCRIPTION
The [.gov registrar](https://domains.dotgov.gov) recently made a change that allows a new domain to opt-in to HSTS preloading at registration. 

This change makes an announcement in "recent updates" and updates the HSTS documentation accordingly.