### PR TITLE
Remove M-08-23 citation

### DIFF
--- a/pages/support/dns.md
+++ b/pages/support/dns.md
@@ -16,8 +16,6 @@ You must provide at least one primary and secondary name server.
 
 You will not be able to specify an IP address for your name servers unless they are child name servers of the domain you’re trying to register or update.
 
-To learn more about the federal DNS policy, review the memorandum [M-08-23: Securing the Federal Government’s Domain Name System Infrastructure Memorandum](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2008/m08-23.pdf) or [download the PDF](https://domains.dotgov.gov/dotgov-web/files/get_file?uuid=0d2b7be9-1c4d-423e-b3fa-6c9cd6310613&groupId=12665&action=get_file).
-
 ### How quickly will changes to my domain propagate throughout the internet?
 
 Propagation depends on a variety of factors, such as caching and connectivity. The changes are usually effective within 24 hours.


### PR DESCRIPTION
OMB [has rescinded](https://www.whitehouse.gov/wp-content/uploads/2018/08/M-18-23.pdf#page=12) the 2008 memo [M-08-23](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2008/m08-23.pdf). This change removes our link to the memo and the text around it.