### PR TITLE
Move feds to December

### DIFF
--- a/pages/support/2step.md
+++ b/pages/support/2step.md
@@ -37,7 +37,7 @@ You will need to add 2-step verification to your account at [https://domains.dot
 
 * _GSA-owned domains_: October 1 - 31
 * _Federal Agency_: October 8 - November 7
-* _Native Sovereign Nation_: October 8 -  November 7
+* _Native Sovereign Nation_: October 8 -  December 7
 * _County_: October 22 - November 21
 * _State/Local Govt_: November 5 - December 5
 * _City_: Done in phases, based on the *first letter of your username*:


### PR DESCRIPTION
To account for challenges in certain environments, this change shifts enforcement for federal agencies back one month.